### PR TITLE
sbt-github-pages v0.1.0

### DIFF
--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,5 @@
+## 0.1.0 - 2020-06-16
+
+### Done
+* Added: `GitHubPagesPlugin` to publish `gh-pages` (#18)
+* [All PRs](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aclosed+milestone%3Amilestone1)


### PR DESCRIPTION
## 0.1.0 - 2020-06-16

### Done
* Added: `GitHubPagesPlugin` to publish `gh-pages` (#18)
* [All PRs](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aclosed+milestone%3Amilestone1)