### PR TITLE
sbt-github-pages v0.1.2

### DIFF
--- a/changelogs/0.1.2.md
+++ b/changelogs/0.1.2.md
@@ -1,0 +1,5 @@
+## [0.1.2](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone3%22) - 2020-07-03
+
+### Fixed
+* `publishToGitHubPages` does not report error when it fails (#49)
+* Error when there is any directory with no file in it (#51)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -2,7 +2,7 @@ import wartremover.{Wart, Warts}
 
 object ProjectInfo {
 
-  val ProjectVersion: String = "0.1.1"
+  val ProjectVersion: String = "0.1.2"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-github-pages v0.1.2
## [0.1.2](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone3%22) - 2020-07-03

### Fixed
* `publishToGitHubPages` does not report error when it fails (#49)
* Error when there is any directory with no file in it (#51)
