### PR TITLE
sbt-github-pages v0.1.3

### DIFF
--- a/changelogs/0.1.3.md
+++ b/changelogs/0.1.3.md
@@ -1,0 +1,4 @@
+## [0.1.3](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone4%22) - 2020-07-28
+
+### Fixed
+* Some failed cases of `publishToGitHubPages` task should fail properly (#59)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -2,7 +2,7 @@ import wartremover.{Wart, Warts}
 
 object ProjectInfo {
 
-  val ProjectVersion: String = "0.1.2"
+  val ProjectVersion: String = "0.1.3"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-github-pages v0.1.3
## [0.1.3](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone4%22) - 2020-07-28

### Fixed
* Some failed cases of `publishToGitHubPages` task should fail properly (#59)
