### PR TITLE
sbt-github-pages v0.2.0

### DIFF
--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,18 @@
+## [0.2.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone5%22) - 2020-09-19
+
+### Done
+* Support GitHub Enterprise (#56)
+  ```scala
+  gitHubPagesGitHubBaseUrl: SettingKey[String]
+  
+  gitHubPagesGitHubAuthorizeUrl: SettingKey[String]
+  
+  gitHubPagesGitHubAccessTokenUrl: SettingKey[String]
+  
+  gitHubPagesGitHubHeaders: SettingKey[Map[String, String]]
+  ```
+* Environment variables for GitHub Enterprise config (#68)
+  * `GITHUB_ENT_BASE_URL` for `gitHubPagesGitHubBaseUrl`
+  * `GITHUB_ENT_AUTHORIZE_URL` for  `gitHubPagesGitHubAuthorizeUrl`
+  * `GITHUB_ENT_ACCESS_TOKEN_URL` for `gitHubPagesGitHubAccessTokenUrl`
+  * `GITHUB_ENT_HEADERS` for `gitHubPagesGitHubHeaders`

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -2,7 +2,7 @@ import wartremover.{Wart, Warts}
 
 object ProjectInfo {
 
-  val ProjectVersion: String = "0.1.3"
+  val ProjectVersion: String = "0.2.0"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-github-pages v0.2.0
## [0.2.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone5%22) - 2020-09-19

### Done
* Support GitHub Enterprise (#56)
  ```scala
  gitHubPagesGitHubBaseUrl: SettingKey[String]
  
  gitHubPagesGitHubAuthorizeUrl: SettingKey[String]
  
  gitHubPagesGitHubAccessTokenUrl: SettingKey[String]
  
  gitHubPagesGitHubHeaders: SettingKey[Map[String, String]]
  ```
* Environment variables for GitHub Enterprise config (#68)
  * `GITHUB_ENT_BASE_URL` for `gitHubPagesGitHubBaseUrl`
  * `GITHUB_ENT_AUTHORIZE_URL` for  `gitHubPagesGitHubAuthorizeUrl`
  * `GITHUB_ENT_ACCESS_TOKEN_URL` for `gitHubPagesGitHubAccessTokenUrl`
  * `GITHUB_ENT_HEADERS` for `gitHubPagesGitHubHeaders`
