### PR TITLE
sbt-github-pages v0.4.0

### DIFF
--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,0 +1,9 @@
+## [0.4.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone7%22) - 2021-02-19
+
+### Done
+* Upgrade libraries and sbt (#85)
+  * sbt-devoops `1.0.3` => `2.0.0` - Changed: GitHub Actions config accordingly
+  * Cats `2.3.1` => `2.4.2`
+  * Cats Effect `2.3.1` => `2.3.3`
+  * github4s `0.27.1` => `0.28.2`
+  * http4s `0.21.15` => `0.21.19`

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -2,7 +2,7 @@ import wartremover.{Wart, Warts}
 
 object ProjectInfo {
 
-  val ProjectVersion: String = "0.3.0"
+  val ProjectVersion: String = "0.4.0"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-github-pages v0.4.0
## [0.4.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone7%22) - 2021-02-19

### Done
* Upgrade libraries and sbt (#85)
  * sbt-devoops `1.0.3` => `2.0.0` - Changed: GitHub Actions config accordingly
  * Cats `2.3.1` => `2.4.2`
  * Cats Effect `2.3.1` => `2.3.3`
  * github4s `0.27.1` => `0.28.2`
  * http4s `0.21.15` => `0.21.19`
