### PR TITLE
Updated: manual-publish-github-pages.yml

### DIFF
--- a/.github/workflows/manual-publish-github-pages.yml
+++ b/.github/workflows/manual-publish-github-pages.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build_and_publish_doc_site:
+    if: github.ref != 'refs/heads/gh-pages' && github.ref != 'gh-pages'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Updated: `manual-publish-github-pages.yml` - The condition to ignore the `gh-pages` branch for building the doc site.