### PR TITLE
sbt-github-pages v0.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val root = (project in file("."))
     startYear := 2020.some,
     Global / sbtVersion := props.GlobalSbtVersion,
     crossSbtVersions := props.CrossSbtVersions,
-    pluginCrossBuild / sbtVersion := "1.2.8",
+    pluginCrossBuild / sbtVersion := props.GlobalSbtVersion,
     Compile / console / scalacOptions := scalacOptions.value diff List("-Ywarn-unused-import", "-Xfatal-warnings"),
     Compile / compile / wartremoverErrors ++= commonWarts,
     Test / compile / wartremoverErrors ++= commonWarts,
@@ -40,7 +40,6 @@ lazy val root = (project in file("."))
     docusaurBuildDir := docusaurDir.value / "build",
     gitHubPagesOrgName := "Kevin-Lee",
     gitHubPagesRepoName := "sbt-github-pages",
-
     /* } Docs */
 
   )
@@ -55,28 +54,37 @@ lazy val props =
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
     val hedgehogVersion: String = "0.6.7"
-    val http4sVersion: String   = "0.21.22"
+
+    val catsVersion       = "2.6.0"
+    val catsEffectVersion = "2.5.0"
+    val github4sVersion   = "0.28.4"
+    val circeVersion      = "0.13.0"
+
+    val http4sVersion: String = "0.21.22"
+
+    val effectieVersion = "1.10.0"
+    val loggerFVersion  = "1.10.0"
   }
 
 lazy val libs =
   new {
-    lazy val hedgehogLibs: Seq[ModuleID] = Seq(
+    lazy val hedgehogLibs = List(
       "qa.hedgehog" %% "hedgehog-core"   % props.hedgehogVersion % Test,
       "qa.hedgehog" %% "hedgehog-runner" % props.hedgehogVersion % Test,
       "qa.hedgehog" %% "hedgehog-sbt"    % props.hedgehogVersion % Test,
     )
 
-    lazy val cats: ModuleID        = "org.typelevel" %% "cats-core"    % "2.6.0"
-    lazy val catsEffect: ModuleID  = "org.typelevel" %% "cats-effect"  % "2.5.0"
-    lazy val github4s: ModuleID    = "com.47deg"     %% "github4s"     % "0.28.4"
-    lazy val circeParser: ModuleID = "io.circe"      %% "circe-parser" % "0.13.0"
+    lazy val cats        = "org.typelevel" %% "cats-core"    % props.catsVersion
+    lazy val catsEffect  = "org.typelevel" %% "cats-effect"  % props.catsEffectVersion
+    lazy val github4s    = "com.47deg"     %% "github4s"     % props.github4sVersion
+    lazy val circeParser = "io.circe"      %% "circe-parser" % props.circeVersion
 
-    lazy val http4sDsl: ModuleID    = "org.http4s" %% "http4s-dsl"          % props.http4sVersion
-    lazy val http4sClient: ModuleID = "org.http4s" %% "http4s-blaze-client" % props.http4sVersion
+    lazy val http4sDsl    = "org.http4s" %% "http4s-dsl"          % props.http4sVersion
+    lazy val http4sClient = "org.http4s" %% "http4s-blaze-client" % props.http4sVersion
 
-    lazy val effectie: ModuleID          = "io.kevinlee" %% "effectie-cats-effect" % "1.10.0"
-    lazy val loggerFCatsEffect: ModuleID = "io.kevinlee" %% "logger-f-cats-effect" % "1.10.0"
-    lazy val loggerFSbtLogging: ModuleID = "io.kevinlee" %% "logger-f-sbt-logging" % "1.10.0"
+    lazy val effectie          = "io.kevinlee" %% "effectie-cats-effect" % props.effectieVersion
+    lazy val loggerFCatsEffect = "io.kevinlee" %% "logger-f-cats-effect" % props.loggerFVersion
+    lazy val loggerFSbtLogging = "io.kevinlee" %% "logger-f-sbt-logging" % props.loggerFVersion
 
     lazy val all: List[ModuleID] =
       List(

--- a/changelogs/0.5.0.md
+++ b/changelogs/0.5.0.md
@@ -1,0 +1,13 @@
+## [0.5.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2021-05-03
+
+### Done
+* Upgrade sbt plugin and libraries (#93)
+  * sbt `1.4.9` => `1.5.1`
+  * sbt-devoops `2.1.0` => `2.3.0`
+  * http4s `0.21.20` => `0.21.22`
+  * cats-core `2.4.2` => `2.6.0`
+  * cats-effect `2.3.3` => `2.5.0`
+  * github4s `0.28.2` => `0.28.4`
+  * effectie `1.9.0` => `1.10.0`
+  * logger-f `1.9.0` => `1.10.0`
+* Publish directly to Maven Central (#96)


### PR DESCRIPTION
# sbt-github-pages v0.5.0
## [0.5.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2021-05-03

### Done
* Upgrade sbt plugin and libraries (#93)
  * sbt `1.4.9` => `1.5.1`
  * sbt-devoops `2.1.0` => `2.3.0`
  * http4s `0.21.20` => `0.21.22`
  * cats-core `2.4.2` => `2.6.0`
  * cats-effect `2.3.3` => `2.5.0`
  * github4s `0.28.2` => `0.28.4`
  * effectie `1.9.0` => `1.10.0`
  * logger-f `1.9.0` => `1.10.0`
* Publish directly to Maven Central (#96)
