### PR TITLE
Add default values for org/repo names extracted from `git remote` info

### DIFF
--- a/src/main/scala/githubpages/GitHubPagesKeys.scala
+++ b/src/main/scala/githubpages/GitHubPagesKeys.scala
@@ -46,10 +46,16 @@ trait GitHubPagesKeys {
     settingKey[Boolean]("The flag to decide whether to add .nojekyll (default: true)")
 
   lazy val gitHubPagesOrgName: SettingKey[String] =
-    settingKey[String]("The GitHub organization name (or username) (e.g. https://github.com/OrgName/RepoName)")
+    settingKey[String](
+      "The GitHub organization name (or username) (e.g. https://github.com/OrgName/RepoName) " +
+        "(default: information obtained from `git remote`)"
+    )
 
   lazy val gitHubPagesRepoName: SettingKey[String] =
-    settingKey[String]("The GitHub project repository name (e.g. https://github.com/OrgName/RepoName)")
+    settingKey[String](
+      "The GitHub project repository name (e.g. https://github.com/OrgName/RepoName) " +
+        "(default: information obtained from `git remote`)"
+    )
 
   lazy val gitHubPagesGitHubToken: SettingKey[Option[String]] =
     settingKey[Option[String]](

--- a/src/main/scala/githubpages/GitHubPagesPlugin.scala
+++ b/src/main/scala/githubpages/GitHubPagesPlugin.scala
@@ -145,6 +145,8 @@ object GitHubPagesPlugin extends AutoPlugin {
     gitHubPagesIgnoreDotDirs := true,
     gitHubPagesAcceptedTextExtensions := GitHubApi.defaultTextExtensions,
     gitHubPagesAcceptedTextMaxLength := GitHubApi.defaultMaximumLength,
+    gitHubPagesOrgName := gitRemoteInfo._1,
+    gitHubPagesRepoName := gitRemoteInfo._2,
     publishToGitHubPages := Def.taskDyn {
 
       val siteDir = Data.SiteDir(gitHubPagesSiteDir.value)

--- a/src/main/scala/githubpages/GitHubPagesPlugin.scala
+++ b/src/main/scala/githubpages/GitHubPagesPlugin.scala
@@ -247,4 +247,25 @@ object GitHubPagesPlugin extends AutoPlugin {
     }.value
   )
 
+  /** Gets the Github user and repository from the git remote info */
+  private val gitRemoteInfo = {
+    import scala.sys.process._
+
+    val identifier = """([^\/]+?)"""
+    val GitHubHttps = s"https://github.com/$identifier/$identifier(?:\\.git)?".r
+    val GitHubGit   = s"git://github.com:$identifier/$identifier(?:\\.git)?".r
+    val GitHubSsh   = s"git@github.com:$identifier/$identifier(?:\\.git)?".r
+    try {
+      val remote = List("git", "ls-remote", "--get-url", "origin").!!.trim()
+      remote match {
+        case GitHubHttps(user, repo) => (user, repo)
+        case GitHubGit(user, repo)   => (user, repo)
+        case GitHubSsh(user, repo)   => (user, repo)
+        case _                       => ("", "")
+      }
+    } catch {
+      case NonFatal(_) => ("", "")
+    }
+  }
+
 }

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -8,9 +8,11 @@ Add set `GitHubPagesPlugin` in the `build.sbt`.
 ## Essential settings
 You probably need only these three setting keys in your project config to publish GitHub Pages.
 ```scala
+gitHubPagesSiteDir := baseDirectory.value / "path/to/github-pages-root"
+
+// These aren't mandatory unless sbt-github-pages can't infer them from `git remote`
 gitHubPagesOrgName := "USERNAME_OR_ORG",
 gitHubPagesRepoName := "YOUR_PROJECT",
-gitHubPagesSiteDir := baseDirectory.value / "path/to/github-pages-root"
 ```
 
 e.g.)
@@ -32,11 +34,13 @@ lazy val root = (project in file("."))
 This key must be set by the user of this plugin.
 :::
 
-| Name                 | Value Type | Default    |
-| -------------------- | ---------- | ---------- |
-| `gitHubPagesOrgName` | `String`   |            |
+| Name                 | Value Type | Default                                  |
+| -------------------- | ---------- | ---------------------------------------- |
+| `gitHubPagesOrgName` | `String`   | Value obtained from calling `git remote` |
 
-The GitHub organization name (or username) (i.e.`OrgName` from `https://github.com/OrgName/RepoName`)
+The GitHub organization name (or username) (i.e.`OrgName` from `https://github.com/OrgName/RepoName`).
+
+Most of the times you won't need to set this setting, since `sbt-github-pages` will try to read it from the `git remote` information.
 
 e.g.)
 ```scala
@@ -50,11 +54,13 @@ gitHubPagesOrgName := "Kevin-Lee"
 This key must be set by the user of this plugin.
 :::
 
-| Name                  | Value Type | Default    |
-| --------------------- | ---------- | ---------- |
-| `gitHubPagesRepoName` | `String`  |            |
+| Name                  | Value Type | Default                                  |
+| --------------------- | ---------- | ---------------------------------------- |
+| `gitHubPagesRepoName` | `String`   | Value obtained from calling `git remote` |
 
-The GitHub project repository name (i.e. `RepoName` from `https://github.com/OrgName/RepoName`)
+The GitHub project repository name (i.e. `RepoName` from `https://github.com/OrgName/RepoName`).
+
+Most of the times you won't need to set this setting, since `sbt-github-pages` will try to read it from the `git remote` information.
 
 e.g.)
 ```scala


### PR DESCRIPTION
# What has been done in this PR?

- Adapt code from [`sbt-ci-release`](https://github.com/olafurpg/sbt-ci-release/blob/3909fc9ef852940f726b1c1973d3cf56a24268e4/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala#L109-L124) to retrieve organization/repository names from `git remote` information.
- Use previous extracted information to populate default values for `gitHubPagesOrgName`/`gitHubPagesRepoName`.
- Update documentation to reflect this change.