### PR TITLE
sbt-github-pages v0.6.0

### DIFF
--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -1,0 +1,4 @@
+## [0.6.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+-label%3Arelease+milestone%3Amilestone9) - 2021-07-09
+
+### Done
+* Add default values for org/repo names extracted from `git remote` info (#102) - Thanks @alejandrohdezma 


### PR DESCRIPTION
# sbt-github-pages v0.6.0
## [0.6.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+-label%3Arelease+milestone%3Amilestone9) - 2021-07-09

### Done
* Add default values for org/repo names extracted from `git remote` info (#102) - Thanks @alejandrohdezma 
