### PR TITLE
sbt-github-pages v0.7.0

### DIFF
--- a/changelogs/0.7.0.md
+++ b/changelogs/0.7.0.md
@@ -1,0 +1,13 @@
+## [0.7.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone10) - 2021-09-19
+
+### Done
+* Upgraded libs and sbt plugins (#106)
+  * `cats` `2.6.0` => `2.6.1`
+  * `cats-effect` `2.5.0` => `2.5.3`
+  * `github4s` `0.28.4` => `0.28.5`
+  * `github4s` `0.28.4` => `0.28.5`
+  * `circe` `0.13.0` => `0.14.1`
+  * `http4s` `0.21.22` => `0.21.27`
+  * `effectie` `1.10.0` => `1.15.0`
+  * `logger-f` `1.10.0` => `1.15.0`
+  * `sbt-devoops` `2.6.0` => `2.10.0`


### PR DESCRIPTION
# sbt-github-pages v0.7.0
## [0.7.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone10) - 2021-09-19

### Done
* Upgraded libs and sbt plugins (#106)
  * `cats` `2.6.0` => `2.6.1`
  * `cats-effect` `2.5.0` => `2.5.3`
  * `github4s` `0.28.4` => `0.28.5`
  * `github4s` `0.28.4` => `0.28.5`
  * `circe` `0.13.0` => `0.14.1`
  * `http4s` `0.21.22` => `0.21.27`
  * `effectie` `1.10.0` => `1.15.0`
  * `logger-f` `1.10.0` => `1.15.0`
  * `sbt-devoops` `2.6.0` => `2.10.0`
