### PR TITLE
sbt-github-pages v0.8.0

### DIFF
--- a/changelogs/0.8.0.md
+++ b/changelogs/0.8.0.md
@@ -1,0 +1,4 @@
+## [0.8.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone11) - 2021-09-29
+
+### Done
+* Add a link to the doc site to explain how to create publish branch (#114)


### PR DESCRIPTION
# sbt-github-pages v0.8.0
## [0.8.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone11) - 2021-09-29

### Done
* Add a link to the doc site to explain how to create publish branch (#114)
