### PR TITLE
sbt-github-pages v0.8.1

### DIFF
--- a/changelogs/0.8.1.md
+++ b/changelogs/0.8.1.md
@@ -1,0 +1,4 @@
+## [0.8.1](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone12) - 2021-11-20
+
+### Fix
+* `publishToGitHubPages` fails if you have greater than 30 branches alphabetically before `gh-pages` (#119) - Thanks @zarthross for the helpful bug report!


### PR DESCRIPTION
# sbt-github-pages v0.8.1
## [0.8.1](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone12) - 2021-11-20

### Fix
* `publishToGitHubPages` fails if you have greater than 30 branches alphabetically before `gh-pages` (#119) - Thanks @zarthross for the helpful bug report!
