### PR TITLE
sbt-github-pages v0.9.0

### DIFF
--- a/changelogs/0.9.0.md
+++ b/changelogs/0.9.0.md
@@ -1,0 +1,13 @@
+## [0.9.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone13) - 2022-05-05
+
+### Done
+* Bump `effectie` and `logger-f` to `2.0.0-beta1` (#162)
+* Upgrade libraries (#160)
+  * cats `2.6.1` => `2.7.0`
+  * cats-effect `2.5.3` => `3.3.5`
+  * github4s `0.28.5` => `0.31.0`
+  * http4s `0.21.27` => `0.23.11`
+  * ~~effectie `1.15.0` => `1.16.0`~~
+  * ~~logger-f `1.15.0` => `1.16.0`~~
+  * hedgehog `0.7.0` => `0.8.0`
+* Publish to `s01.oss.sonatype.org` (the new Maven central) (#131)


### PR DESCRIPTION
# sbt-github-pages v0.9.0
## [0.9.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone13) - 2022-05-05

### Done
* Bump `effectie` and `logger-f` to `2.0.0-beta1` (#162)
* Upgrade libraries (#160)
  * cats `2.6.1` => `2.7.0`
  * cats-effect `2.5.3` => `3.3.5`
  * github4s `0.28.5` => `0.31.0`
  * http4s `0.21.27` => `0.23.11`
  * ~~effectie `1.15.0` => `1.16.0`~~
  * ~~logger-f `1.15.0` => `1.16.0`~~
  * hedgehog `0.7.0` => `0.8.0`
* Publish to `s01.oss.sonatype.org` (the new Maven central) (#131)