### PR TITLE
Upgrade: libraries and sbt plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,10 +74,10 @@ lazy val props =
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    final val hedgehogVersion = "0.8.0"
+    final val hedgehogVersion = "0.9.0"
 
     final val catsVersion       = "2.7.0"
-    final val catsEffectVersion = "3.3.5"
+    final val catsEffectVersion = "3.3.12"
     final val github4sVersion   = "0.31.0"
     final val circeVersion      = "0.14.1"
 
@@ -86,7 +86,7 @@ lazy val props =
     final val effectieVersion = "2.0.0-beta1"
     final val loggerFVersion  = "2.0.0-beta1"
 
-    final val ExtrasVersion = "0.13.0"
+    final val ExtrasVersion = "0.14.0"
   }
 
 lazy val libs =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ logLevel := sbt.Level.Warn
 
 addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.10")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
-addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.9.0")
+addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.10.0")
 
-val sbtDevOops = "2.16.0"
+val sbtDevOops = "2.20.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOops)


### PR DESCRIPTION
Upgrade: libraries and sbt plugins
- cats-effect `3.3.5` => `3.3.12`
- extras `0.13.0` => `0.14.0`
- sbt-docusaur `0.9.0` => `0.10.0`
- sbt-devoops `2.16.0` => `2.20.0`