### PR TITLE
sbt-github-pages v0.10.0

### DIFF
--- a/changelogs/0.10.0.md
+++ b/changelogs/0.10.0.md
@@ -1,0 +1,4 @@
+## [0.10.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone14) - 2022-05-21
+
+### Done
+* Add `settingKey` to set the request timeout for publishing GitHub Pages (#165)


### PR DESCRIPTION
# sbt-github-pages v0.10.0
## [0.10.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone14) - 2022-05-21

### Done
* Add `settingKey` to set the request timeout for publishing GitHub Pages (#165)