### PR TITLE
Close #171 - Upgrade Scala, sbt, sbt-plugins and libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val props =
 
     final val Org = "io.kevinlee"
 
-    final val ProjectScalaVersion       = "2.12.12"
+    final val ProjectScalaVersion       = "2.12.17"
     val CrossScalaVersions: Seq[String] = Seq(ProjectScalaVersion)
 
     final val GitHubUsername = gitHubRepo.fold("Kevin-Lee")(_.orgToString)
@@ -76,17 +76,18 @@ lazy val props =
 
     final val hedgehogVersion = "0.9.0"
 
-    final val catsVersion       = "2.7.0"
-    final val catsEffectVersion = "3.3.12"
-    final val github4sVersion   = "0.31.0"
-    final val circeVersion      = "0.14.1"
+    final val catsVersion       = "2.8.0"
+    final val catsEffectVersion = "3.3.14"
+    final val github4sVersion   = "0.31.2"
+    final val circeVersion      = "0.14.3"
 
-    final val http4sVersion = "0.23.11"
+    final val http4sVersion            = "0.23.16"
+    final val http4sBlazeClientVersion = "0.23.12"
 
-    final val effectieVersion = "2.0.0-beta1"
-    final val loggerFVersion  = "2.0.0-beta1"
+    final val effectieVersion = "2.0.0-beta2"
+    final val loggerFVersion  = "2.0.0-beta2"
 
-    final val ExtrasVersion = "0.14.0"
+    final val ExtrasVersion = "0.20.0"
   }
 
 lazy val libs =
@@ -103,11 +104,11 @@ lazy val libs =
     lazy val circeParser = "io.circe"      %% "circe-parser" % props.circeVersion
 
     lazy val http4sDsl    = "org.http4s" %% "http4s-dsl"          % props.http4sVersion
-    lazy val http4sClient = "org.http4s" %% "http4s-blaze-client" % props.http4sVersion
+    lazy val http4sClient = "org.http4s" %% "http4s-blaze-client" % props.http4sBlazeClientVersion
 
     lazy val effectie          = "io.kevinlee" %% "effectie-cats-effect3" % props.effectieVersion
-    lazy val loggerFCatsEffect = "io.kevinlee" %% "logger-f-cats" % props.loggerFVersion
-    lazy val loggerFSbtLogging = "io.kevinlee" %% "logger-f-sbt-logging" % props.loggerFVersion
+    lazy val loggerFCatsEffect = "io.kevinlee" %% "logger-f-cats"         % props.loggerFVersion
+    lazy val loggerFSbtLogging = "io.kevinlee" %% "logger-f-sbt-logging"  % props.loggerFVersion
 
     lazy val extrasCats = "io.kevinlee" %% "extras-cats" % props.ExtrasVersion
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 logLevel := sbt.Level.Warn
 
 addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.10")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.0.6")
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.10.0")
 
-val sbtDevOops = "2.20.0"
+val sbtDevOops = "2.23.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOops)

--- a/src/main/scala/githubpages/GitHubPagesPlugin.scala
+++ b/src/main/scala/githubpages/GitHubPagesPlugin.scala
@@ -10,7 +10,7 @@ import filef.FileF
 import github4s.domain.Ref
 import githubpages.github.Data.GitHubApiConfig
 import githubpages.github.{Data, GitHubApi, GitHubError}
-import loggerf.cats.syntax.all._
+import loggerf.syntax.all._
 import loggerf.core.{Log => LogF}
 import loggerf.logger._
 import org.http4s.blaze.client.BlazeClientBuilder
@@ -163,6 +163,7 @@ object GitHubPagesPlugin extends AutoPlugin {
       val commitMessage  = Data.CommitMessage(gitHubPagesPublishCommitMessage.value)
       val dirsToIgnore   = gitHubPagesDirsToIgnore.value
       val ignoreDotDirs  = gitHubPagesIgnoreDotDirs.value
+      @SuppressWarnings(Array("org.wartremover.warts.PlatformDefault"))
       val dirFilter      =
         if (ignoreDotDirs)
           (dir: File) => !(dirsToIgnore.contains(dir.getName.toLowerCase) || dir.getName.startsWith("."))
@@ -181,8 +182,8 @@ object GitHubPagesPlugin extends AutoPlugin {
       )
 
       import cats.effect.unsafe.implicits.global
-      import effectie.cats.fx.ioFx
-      import loggerf.cats.instances.logF
+      import effectie.ce3.fx.ioFx
+      import loggerf.instances.cats.logF
 
       implicit val log: CanLog = SbtLogger.sbtLoggerCanLog(streams.value.log)
 

--- a/src/main/scala/githubpages/github/Data.scala
+++ b/src/main/scala/githubpages/github/Data.scala
@@ -99,6 +99,7 @@ object Data {
 
   final case class IsText(blobConfig: BlobConfig) extends ((File, Array[Byte]) => Boolean) {
 
+    @SuppressWarnings(Array("org.wartremover.warts.PlatformDefault"))
     override def apply(file: File, bytes: Array[Byte]): Boolean =
       blobConfig.acceptedExtensions.exists(extension => file.getName.toLowerCase.endsWith(extension)) &&
         bytes.length < blobConfig.maxLength

--- a/src/main/scala/githubpages/github/GitHubApi.scala
+++ b/src/main/scala/githubpages/github/GitHubApi.scala
@@ -1,25 +1,26 @@
 package githubpages.github
 
-import cats._
+import cats.*
 import cats.data.{EitherT, NonEmptyVector}
 import cats.effect.{Concurrent, Temporal}
-import cats.syntax.all._
-import extras.cats.syntax.either._
+import cats.syntax.all.*
+import extras.cats.syntax.either.*
 import effectie.core.Fx
-import effectie.syntax.all._
+import effectie.syntax.all.*
 import filef.FileF
-import github4s.domain._
+import github4s.domain.*
 import github4s.http.HttpClient
 import github4s.interpreters.StaticAccessToken
 import github4s.{GHError, GHResponse, Github, GithubConfig}
 import githubpages.github.Data.{CommitInfo, GitHubApiConfig}
 import loggerf.core.Log
-import loggerf.cats.syntax.all._
+import loggerf.syntax.all.*
 import org.http4s.client.Client
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 import java.util.Base64
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /** @author Kevin Lee
   * @since 2020-05-27
@@ -157,7 +158,8 @@ object GitHubApi {
       headers: Map[String, String],
     ): EitherT[F, GitHubError, TreeData] =
       if (isText(file, bytes))
-        pureOf(TreeDataBlob(filePath, blobMode, blobType, new String(bytes)): TreeData).rightT[GitHubError]
+        pureOf(TreeDataBlob(filePath, blobMode, blobType, new String(bytes, StandardCharsets.UTF_8)): TreeData)
+          .rightT[GitHubError]
       else
         treeDataWithBase64Encoding(github, gitHubRepo, filePath, bytes, headers)
 


### PR DESCRIPTION
Close #171 - Upgrade Scala, sbt, sbt-plugins and libraries
* sbt 1.6.2 => 1.7.2
* Scala 2.12.12 => 2.12.17
* cats 2.7.0 => 2.8.0
* cats-effect 3.3.12 => 3.3.14
* github4s 0.31.0 => 0.31.2
* circe 0.14.1 => 0.14.3
* http4s 0.23.11 => 0.23.16
* http4s-blaze-client 0.23.12
* effectie 2.0.0-beta1 => 2.0.0-beta2
* logger-f 2.0.0-beta1 => 2.0.0-beta2
* extras 0.14.0 => 0.20.0