### PR TITLE
sbt-github-pages v0.12.0

### DIFF
--- a/changelogs/0.12.0.md
+++ b/changelogs/0.12.0.md
@@ -1,0 +1,12 @@
+## [0.12.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone16) - 2022-12-28
+
+### Done
+* Upgrade `effectie` and `logger-f` to `2.0.0-beta4` (#180) - and update the code accordingly / also upgrade other libraries
+  * effectie`2.0.0-beta2` => `2.0.0-beta4`
+  * logger-f`2.0.0-beta2` => `2.0.0-beta4`
+  * global sbt version`1.2.8` => `1.6.2`
+  * hedgehog`0.9.0` => `0.10.1`
+  * cats`2.8.0` => `2.9.0`
+  * cats-effect`3.3.14` => `3.4.3`
+  * http4s blaze client`0.23.12` => `0.23.13`
+  * extras`0.20.0` => `0.26.0`


### PR DESCRIPTION
# sbt-github-pages v0.12.0
## [0.12.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone16) - 2022-12-28

### Done
* Upgrade `effectie` and `logger-f` to `2.0.0-beta4` (#180) - and update the code accordingly / also upgrade other libraries
  * effectie`2.0.0-beta2` => `2.0.0-beta4`
  * logger-f`2.0.0-beta2` => `2.0.0-beta4`
  * global sbt version`1.2.8` => `1.6.2`
  * hedgehog`0.9.0` => `0.10.1`
  * cats`2.8.0` => `2.9.0`
  * cats-effect`3.3.14` => `3.4.3`
  * http4s blaze client`0.23.12` => `0.23.13`
  * extras`0.20.0` => `0.26.0`
