### PR TITLE
Close #200 - Upgrade Scala, sbt, sbt plugins and libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val props =
 
     final val Org = "io.kevinlee"
 
-    final val ProjectScalaVersion       = "2.12.17"
+    final val ProjectScalaVersion       = "2.12.18"
     val CrossScalaVersions: Seq[String] = Seq(ProjectScalaVersion)
 
     final val GitHubUsername = gitHubRepo.fold("Kevin-Lee")(_.orgToString)
@@ -76,18 +76,18 @@ lazy val props =
 
     final val hedgehogVersion = "0.10.1"
 
-    final val CatsVersion       = "2.9.0"
-    final val CatsEffectVersion = "3.4.3"
-    final val Github4sVersion   = "0.31.2"
-    final val CirceVersion      = "0.14.3"
+    final val CatsVersion       = "2.10.0"
+    final val CatsEffectVersion = "3.5.2"
+    final val Github4sVersion   = "0.32.1"
+    final val CirceVersion      = "0.14.6"
 
-    final val Http4sVersion            = "0.23.16"
-    final val Http4sBlazeClientVersion = "0.23.13"
+    final val Http4sVersion            = "0.23.24"
+    final val Http4sBlazeClientVersion = "0.23.15"
 
-    final val EffectieVersion = "2.0.0-beta4"
-    final val LoggerFVersion  = "2.0.0-beta4"
+    final val EffectieVersion = "2.0.0-beta13"
+    final val LoggerFVersion  = "2.0.0-beta22"
 
-    final val ExtrasVersion = "0.26.0"
+    final val ExtrasVersion = "0.44.0"
   }
 
 lazy val libs =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.10")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.0.6")
+addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.12")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.5")
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.13.0")
 
-val sbtDevOops = "2.24.0"
+val sbtDevOops = "3.0.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOops)

--- a/src/main/scala/filef/FileError.scala
+++ b/src/main/scala/filef/FileError.scala
@@ -12,13 +12,13 @@ sealed trait FileError
 
 object FileError {
 
-  final case class FileNotFound private (
+  final case class FileNotFound(
     fileNotFoundException: FileNotFoundException
   ) extends FileError
 
-  final case class Io private (ioException: IOException) extends FileError
+  final case class Io(ioException: IOException) extends FileError
 
-  final case class Unknown private (throwable: Throwable) extends FileError
+  final case class Unknown(throwable: Throwable) extends FileError
 
   final case class NotDirectory(file: File) extends FileError
 


### PR DESCRIPTION
Close #200 - Upgrade Scala, sbt, sbt plugins and libraries
* Scala to `2.12.18`
* sbt to `1.9.7`
* sbt-ci-release to `1.5.12`
* sbt-wartremover to `3.1.5`
* sbt-devoops to `3.0.0`
* cats to `2.10.0`
* cats-effect to `3.5.2`
* github4s to `0.32.1`
* circe to `0.14.6`
* http4s to `0.23.24`
* http4s-blaze-client to `0.23.15`
* effectie to `2.0.0-beta13`
* logger-f to `2.0.0-beta22`
* extras to `0.44.0`
