### PR TITLE
sbt-github-pages v0.13.0

### DIFF
--- a/changelogs/0.13.0.md
+++ b/changelogs/0.13.0.md
@@ -1,0 +1,18 @@
+## [0.13.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone17) - 2023-11-19
+
+### Internal Housekeeping
+* Upgrade Scala, sbt, sbt plugins and libraries (#200)
+  * Scala to `2.12.18`
+  * sbt to `1.9.7`
+  * sbt-ci-release to `1.5.12`
+  * sbt-wartremover to `3.1.5`
+  * sbt-devoops to `3.0.0`
+  * cats to `2.10.0`
+  * cats-effect to `3.5.2`
+  * github4s to `0.32.1`
+  * circe to `0.14.6`
+  * http4s to `0.23.24`
+  * http4s-blaze-client to `0.23.15`
+  * effectie to `2.0.0-beta13`
+  * logger-f to `2.0.0-beta22`
+  * extras to `0.44.0`


### PR DESCRIPTION
# sbt-github-pages v0.13.0
## [0.13.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Arelease+milestone%3Amilestone17) - 2023-11-19

### Internal Housekeeping
* Upgrade Scala, sbt, sbt plugins and libraries (#200)
  * Scala to `2.12.18`
  * sbt to `1.9.7`
  * sbt-ci-release to `1.5.12`
  * sbt-wartremover to `3.1.5`
  * sbt-devoops to `3.0.0`
  * cats to `2.10.0`
  * cats-effect to `3.5.2`
  * github4s to `0.32.1`
  * circe to `0.14.6`
  * http4s to `0.23.24`
  * http4s-blaze-client to `0.23.15`
  * effectie to `2.0.0-beta13`
  * logger-f to `2.0.0-beta22`
  * extras to `0.44.0`
