### PR TITLE
Allow force push

### DIFF
--- a/src/main/scala/githubpages/GitHubPagesKeys.scala
+++ b/src/main/scala/githubpages/GitHubPagesKeys.scala
@@ -96,6 +96,13 @@ trait GitHubPagesKeys {
         s"""If not found, the default value is "Updated $${gitHubPagesBranch.value}""""
     )
 
+  lazy val gitHubPagesPublishForcePush: SettingKey[Boolean] =
+    settingKey[Boolean](
+      "Whether to force push to the specified branch when publish to GitHub Pages. " +
+        "First, it tries to get the value from the environment variable 'GITHUB_PAGES_PUBLISH_FORCE_PUSH'. " +
+        "If not found, the default value is false"
+    )
+
   val DefaultGitHubPagesPublishRequestTimeout: FiniteDuration = org.http4s.client.defaults.RequestTimeout
 
   lazy val gitHubPagesPublishRequestTimeout: SettingKey[FiniteDuration] =

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -255,6 +255,30 @@ gitHubPagesPublishCommitMessage :=
 e.g.) If you want to have a different message, you can change it.
 ```scala
 gitHubPagesPublishCommitMessage := s"New stuff in my awesome website!!!"
+
+
+### Publish Force Push
+| Name                           | Value Type | Default                                                                               |
+| ------------------------------ | ---------- | ------------------------------------------------------------------------------------- |
+| `gitHubPagesPublishForcePush`  | `Boolean`  | ENV VAR `GITHUB_PAGES_PUBLISH_FORCE_PUSH` or false |
+
+The commit message when publish to GitHub Pages. 
+
+First, it tries to get the value from the environment variable `GITHUB_PAGES_PUBLISH_FORCE_PUSH`. 
+If not found, the default value is false
+
+Default:
+```scala
+gitHubPagesPublishCommitMessage :=
+  sys.env.getOrElse(
+    "GITHUB_PAGES_PUBLISH_FORCE_PUSH",
+    false
+  )
+```
+
+e.g.) If you want to, you can enable force push.
+```scala
+gitHubPagesPublishForcePush := true
 ```
 
 ## Use GitHub Enterprise


### PR DESCRIPTION
This allows the plugin to force push to the configured branch. I haven't fully tested this because I'm not very familiar with sbt plugin development, but I believe this should work. Any help would be appreciated.