### PR TITLE
sbt-github-pages v0.14.0

### DIFF
--- a/changelogs/0.14.0.md
+++ b/changelogs/0.14.0.md
@@ -1,0 +1,16 @@
+## [0.14.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aclosed+-label%3Arelease+label%3Achangelog+milestone%3Amilestone18) - 2024-03-05
+
+### New Feature
+* Allow force push (#213) - Thanks @michaelmior
+  * force push with the environment variable `GITHUB_PAGES_PUBLISH_FORCE_PUSH`
+
+### Internal Housekeeping
+* Bump libraries (#214)
+  * cats-effect to `3.5.3`
+  * http4s to `0.23.25`
+  * http4s-blaze-client to `0.23.16`
+  * effectie to `2.0.0-beta14`
+  * logger-f to `2.0.0-beta24`
+
+* Add `sbt-devoops-starter` (#216)
+* Bump `sbt-devoops` to `3.1.0` (#218)


### PR DESCRIPTION
# sbt-github-pages v0.14.0
## [0.14.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aclosed+-label%3Arelease+label%3Achangelog+milestone%3Amilestone18) - 2024-03-05

### New Feature
* Allow force push (#213) - Thanks @michaelmior
  * force push with the environment variable `GITHUB_PAGES_PUBLISH_FORCE_PUSH`

### Internal Housekeeping
* Bump libraries (#214)
  * cats-effect to `3.5.3`
  * http4s to `0.23.25`
  * http4s-blaze-client to `0.23.16`
  * effectie to `2.0.0-beta14`
  * logger-f to `2.0.0-beta24`

* Add `sbt-devoops-starter` (#216)
* Bump `sbt-devoops` to `3.1.0` (#218)
