### PR TITLE
Close #234 - Bump libraries and sbt plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,18 +74,18 @@ lazy val props =
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    final val hedgehogVersion = "0.10.1"
+    final val hedgehogVersion = "0.12.0"
 
-    final val CatsVersion       = "2.10.0"
-    final val CatsEffectVersion = "3.5.3"
-    final val Github4sVersion   = "0.32.1"
-    final val CirceVersion      = "0.14.6"
+    final val CatsVersion       = "2.13.0"
+    final val CatsEffectVersion = "3.5.7"
+    final val Github4sVersion   = "0.33.3"
+    final val CirceVersion      = "0.14.12"
 
-    final val Http4sVersion            = "0.23.25"
-    final val Http4sBlazeClientVersion = "0.23.16"
+    final val Http4sVersion            = "0.23.30"
+    final val Http4sBlazeClientVersion = "0.23.17"
 
-    final val EffectieVersion = "2.0.0-beta14"
-    final val LoggerFVersion  = "2.0.0-beta24"
+    final val EffectieVersion = "2.0.0"
+    final val LoggerFVersion  = "2.1.18"
 
     final val ExtrasVersion = "0.44.0"
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,8 @@ addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.12")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.5")
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.16.0")
 
-val sbtDevOops = "3.1.0"
+val sbtDevOops = "3.2.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOops)
-addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"    % sbtDevOops)
+addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"   % sbtDevOops)


### PR DESCRIPTION
# Close #234 - Bump libraries and sbt plugins
Update dependencies and refactor GitHub API usage
- Updated library versions in `build.sbt`:
  - hedgehog to 0.12.0
  - cats to 2.13.0
  - cats-effect to 3.5.7
  - github4s to 0.33.3
  - circe to 0.14.12
  - http4s to 0.23.30
  - http4s-blaze-client to 0.23.17
  - effectie to 2.0.0
  - logger-f to 2.1.18
- Updated sbt-devoops version to 3.2.0 in `project/plugins.sbt`.
- Refactored `GitHubApi.scala` to use `GithubAPIs` instead of `Github`.