### PR TITLE
sbt-github-pages v0.15.0

### DIFF
--- a/changelogs/0.15.0.md
+++ b/changelogs/0.15.0.md
@@ -1,0 +1,17 @@
+## [0.15.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Amilestone19%20) - 2025-04-06
+
+### Internal Housekeeping
+* Bump libraries and sbt plugins (#234)
+
+  - Updated library versions in `build.sbt`:
+    - `hedgehog` to `0.12.0`
+    - `cats` to `2.13.0`
+    - `cats-effect` to `3.5.7`
+    - `github4s` to `0.33.3`
+    - `circe` to `0.14.12`
+    - `http4s` to `0.23.30`
+    - `http4s-blaze-client` to `0.23.17`
+    - `effectie` to `2.0.0`
+    - `logger-f` to `2.1.18`
+  - Updated `sbt-devoops` version to `3.2.0` in `project/plugins.sbt`.
+  - Refactored `GitHubApi.scala` to use `GithubAPIs` instead of `Github`.


### PR DESCRIPTION
# sbt-github-pages v0.15.0
## [0.15.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Amilestone19%20) - 2025-04-06

### Internal Housekeeping
* Bump libraries and sbt plugins (#234)

  - Updated library versions in `build.sbt`:
    - `hedgehog` to `0.12.0`
    - `cats` to `2.13.0`
    - `cats-effect` to `3.5.7`
    - `github4s` to `0.33.3`
    - `circe` to `0.14.12`
    - `http4s` to `0.23.30`
    - `http4s-blaze-client` to `0.23.17`
    - `effectie` to `2.0.0`
    - `logger-f` to `2.1.18`
  - Updated `sbt-devoops` version to `3.2.0` in `project/plugins.sbt`.
  - Refactored `GitHubApi.scala` to use `GithubAPIs` instead of `Github`.
