### PR TITLE
Close #243: Update libraries, sbt and sbt plugins

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.6.1
+version = 3.9.10
 runner.dialect = scala3
 
 //align.preset=more

--- a/build.sbt
+++ b/build.sbt
@@ -20,8 +20,6 @@ ThisBuild / scmInfo   := ScmInfo(
 
 ThisBuild / startYear := 2020.some
 
-ThisBuild / resolvers += "sonatype-snapshots" at s"https://${props.SonatypeCredentialHost}/content/repositories/snapshots"
-
 Global / sbtVersion := props.GlobalSbtVersion
 
 lazy val root = (project in file("."))
@@ -52,42 +50,38 @@ lazy val root = (project in file("."))
     /* } Docs */
 
   )
-  .settings(mavenCentralPublishSettings)
 
 lazy val props =
   new {
-
-    val SonatypeCredentialHost = "s01.oss.sonatype.org"
-    val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
 
     private val gitHubRepo = findRepoOrgAndName
 
     final val Org = "io.kevinlee"
 
-    final val ProjectScalaVersion       = "2.12.18"
+    final val ProjectScalaVersion       = "2.12.20"
     val CrossScalaVersions: Seq[String] = Seq(ProjectScalaVersion)
 
     final val GitHubUsername = gitHubRepo.fold("Kevin-Lee")(_.orgToString)
     final val ProjectName    = gitHubRepo.fold("sbt-github-pages")(_.nameToString)
 
-    final val GlobalSbtVersion = "1.6.2"
+    final val GlobalSbtVersion = "1.11.2"
 
     val CrossSbtVersions: Seq[String] = Seq(GlobalSbtVersion)
 
-    final val hedgehogVersion = "0.12.0"
+    final val hedgehogVersion = "0.13.0"
 
     final val CatsVersion       = "2.13.0"
-    final val CatsEffectVersion = "3.5.7"
+    final val CatsEffectVersion = "3.6.3"
     final val Github4sVersion   = "0.33.3"
-    final val CirceVersion      = "0.14.12"
+    final val CirceVersion      = "0.14.15"
 
-    final val Http4sVersion            = "0.23.30"
+    final val Http4sVersion            = "0.23.32"
     final val Http4sBlazeClientVersion = "0.23.17"
 
     final val EffectieVersion = "2.0.0"
-    final val LoggerFVersion  = "2.1.18"
+    final val LoggerFVersion  = "2.4.0"
 
-    final val ExtrasVersion = "0.44.0"
+    final val ExtrasVersion = "0.49.0"
   }
 
 lazy val libs =
@@ -126,10 +120,3 @@ lazy val libs =
         extrasCats,
       ) ++ hedgehogLibs
   }
-
-lazy val mavenCentralPublishSettings: SettingsDefinition = List(
-  /* Publish to Maven Central { */
-  sonatypeCredentialHost := props.SonatypeCredentialHost,
-  sonatypeRepository     := props.SonatypeRepository,
-  /* } Publish to Maven Central */
-)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.11.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.12")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.5")
+addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.11.2")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.4.1")
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.17.0")
 
-val sbtDevOops = "3.2.0"
+val sbtDevOops = "3.3.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOops)

--- a/src/main/scala/githubpages/GitHubPagesPlugin.scala
+++ b/src/main/scala/githubpages/GitHubPagesPlugin.scala
@@ -190,7 +190,6 @@ object GitHubPagesPlugin extends AutoPlugin {
 
       import cats.effect.unsafe.implicits.global
       import effectie.instances.ce3.fx.ioFx
-      import loggerf.instances.cats.logF
 
       implicit val log: CanLog = SbtLogger.sbtLoggerCanLog(streams.value.log)
 

--- a/src/main/scala/githubpages/github/GitHubApi.scala
+++ b/src/main/scala/githubpages/github/GitHubApi.scala
@@ -304,10 +304,9 @@ object GitHubApi {
                      },
                    )
     refCommit <- updateCommitFiles(github, commitInfo, baseDir, allFiles, isText, none[Data.CommitSha], headers)
-    headRef   <-
-      refCommit.traverse(commitSha =>
-        updateHead(github, gitHubRepoWithAuth.gitHubRepo, branch, commitSha, headers, forcePush)
-      )
+    headRef   <- refCommit.traverse(commitSha =>
+                   updateHead(github, gitHubRepoWithAuth.gitHubRepo, branch, commitSha, headers, forcePush)
+                 )
   } yield headRef).value
 
   @SuppressWarnings(Array("org.wartremover.warts.ExplicitImplicitTypes"))


### PR DESCRIPTION
## Close #243: Update libraries, sbt and sbt plugins

Update dependencies and build tooling

- Update Scalafmt: `3.6.1` -> `3.9.10`
- Update Scala: `2.12.18` -> `2.12.20`
- Update sbt: `1.9.8` -> `1.11.7` (global: `1.6.2` -> `1.11.2`)
- Update sbt plugins:
  - sbt-ci-release: `1.5.12` -> `1.11.2`
  - sbt-wartremover: `3.1.5` -> `3.4.1`
  - sbt-devoops: `3.2.0` -> `3.3.0`
- Update library dependencies:
  - hedgehog: `0.12.0` -> `0.13.0`
  - cats-effect: `3.5.7` -> `3.6.3`
  - circe: `0.14.12` -> `0.14.15`
  - http4s: `0.23.30` -> `0.23.32`
  - logger-f: `2.1.18` -> `2.4.0`
  - extras: `0.44.0` -> `0.49.0`
- Remove unused sonatype-snapshots resolver (sbt `1.11.7` takes care of Maven Central)
- Remove unused `mavenCentralPublishSettings` (sbt `1.11.7` takes care of Maven Central)
- Remove unused import in `GitHubPagesPlugin` (change from the new `logger-f`)
- formatting