### PR TITLE
sbt-github-pages v0.16.0

### DIFF
--- a/changelogs/0.16.0.md
+++ b/changelogs/0.16.0.md
@@ -1,0 +1,25 @@
+## [0.16.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Am20) - 2025-10-11
+
+### Internal Housekeeping
+#### Update libraries, sbt and sbt plugins (#243)
+
+Update dependencies and build tooling
+
+- Update Scalafmt: `3.6.1` -> `3.9.10`
+- Update Scala: `2.12.18` -> `2.12.20`
+- Update sbt: `1.9.8` -> `1.11.7` (global: `1.6.2` -> `1.11.2`)
+- Update sbt plugins:
+  - sbt-ci-release: `1.5.12` -> `1.11.2`
+  - sbt-wartremover: `3.1.5` -> `3.4.1`
+  - sbt-devoops: `3.2.0` -> `3.3.0`
+- Update library dependencies:
+  - hedgehog: `0.12.0` -> `0.13.0`
+  - cats-effect: `3.5.7` -> `3.6.3`
+  - circe: `0.14.12` -> `0.14.15`
+  - http4s: `0.23.30` -> `0.23.32`
+  - logger-f: `2.1.18` -> `2.4.0`
+  - extras: `0.44.0` -> `0.49.0`
+- Remove unused sonatype-snapshots resolver (sbt `1.11.7` takes care of Maven Central)
+- Remove unused `mavenCentralPublishSettings` (sbt `1.11.7` takes care of Maven Central)
+- Remove unused import in `GitHubPagesPlugin` (change from the new `logger-f`)
+- formatting


### PR DESCRIPTION
# sbt-github-pages v0.16.0
## [0.16.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Am20) - 2025-10-11

### Internal Housekeeping
#### Update libraries, sbt and sbt plugins (#243)

Update dependencies and build tooling

- Update Scalafmt: `3.6.1` -> `3.9.10`
- Update Scala: `2.12.18` -> `2.12.20`
- Update sbt: `1.9.8` -> `1.11.7` (global: `1.6.2` -> `1.11.2`)
- Update sbt plugins:
  - sbt-ci-release: `1.5.12` -> `1.11.2`
  - sbt-wartremover: `3.1.5` -> `3.4.1`
  - sbt-devoops: `3.2.0` -> `3.3.0`
- Update library dependencies:
  - hedgehog: `0.12.0` -> `0.13.0`
  - cats-effect: `3.5.7` -> `3.6.3`
  - circe: `0.14.12` -> `0.14.15`
  - http4s: `0.23.30` -> `0.23.32`
  - logger-f: `2.1.18` -> `2.4.0`
  - extras: `0.44.0` -> `0.49.0`
- Remove unused sonatype-snapshots resolver (sbt `1.11.7` takes care of Maven Central)
- Remove unused `mavenCentralPublishSettings` (sbt `1.11.7` takes care of Maven Central)
- Remove unused import in `GitHubPagesPlugin` (change from the new `logger-f`)
- formatting