### PR TITLE
sbt-github-pages v0.17.0

### DIFF
--- a/changelogs/0.17.0.md
+++ b/changelogs/0.17.0.md
@@ -1,0 +1,9 @@
+## [0.17.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Am21) - 2025-12-29
+
+### New Features
+
+* Fix: Publish fails if the gh-pages branch does not already exist (#113)
+  * When `gitHubPagesBranchExists` is false, create the `gh-pages` branch (from `gitHubPagesBranch`)
+  
+    In general scenario, when running `sbt publishToGitHubPages`, if the `gh-pages` branch is missing,
+    it creates the `gh-pages` branch before pushing files to it.


### PR DESCRIPTION
# sbt-github-pages v0.17.0

## [0.17.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Am21) - 2025-12-29

### New Features

* Fix: Publish fails if the gh-pages branch does not already exist (#113)
  * When `gitHubPagesBranchExists` is false, create the `gh-pages` branch (from `gitHubPagesBranch`)
  
    In general scenario, when running `sbt publishToGitHubPages`, if the `gh-pages` branch is missing,
    it creates the `gh-pages` branch before pushing files to it.
