### PR TITLE
sbt-github-pages v0.17.1

### DIFF
--- a/changelogs/0.17.1.md
+++ b/changelogs/0.17.1.md
@@ -1,0 +1,5 @@
+## [0.17.1](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Am22) - 2025-12-30
+
+### Fixed
+
+* Fix: Commit fails in gh-pages creation (#254)


### PR DESCRIPTION
# sbt-github-pages v0.17.1

## [0.17.1](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Am22) - 2025-12-30

### Fixed

* Fix: Commit fails in gh-pages creation (#254)
