### PR TITLE
Close #257: `publishToGitHubPages` should not run `gitHubPagesCreateGitHubPagesBranchIfNotExist` automatically

### DIFF
--- a/src/main/scala/githubpages/GitHubPagesPlugin.scala
+++ b/src/main/scala/githubpages/GitHubPagesPlugin.scala
@@ -259,9 +259,6 @@ object GitHubPagesPlugin extends AutoPlugin {
 
     },
     publishToGitHubPages := Def.taskDyn {
-
-      gitHubPagesCreateGitHubPagesBranchIfNotExist.value
-
       val gitHubPagesPublishBranch = Data.GitHubPagesBranch(gitHubPagesBranch.value)
 
       val siteDir        = Data.SiteDir(gitHubPagesSiteDir.value)


### PR DESCRIPTION
Close #257: `publishToGitHubPages` should not run `gitHubPagesCreateGitHubPagesBranchIfNotExist` automatically