### PR TITLE
sbt-github-pages v0.18.0

### DIFF
--- a/changelogs/0.18.0.md
+++ b/changelogs/0.18.0.md
@@ -1,0 +1,8 @@
+## [0.18.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Am22) - 2025-12-30
+
+### Fixed
+
+* Fix: Commit fails in gh-pages creation (#254)
+
+### Changes
+* `publishToGitHubPages` should not run `gitHubPagesCreateGitHubPagesBranchIfNotExist` automatically (#257)


### PR DESCRIPTION
# sbt-github-pages v0.18.0

## [0.18.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Am22) - 2025-12-30

### Fixed

* Fix: Commit fails in gh-pages creation (#254)

### Changes
* `publishToGitHubPages` should not run `gitHubPagesCreateGitHubPagesBranchIfNotExist` automatically (#257)
