### PR TITLE
Update `sbt` and `sbt-devoops` plugin versions

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.7
+sbt.version=1.12.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.4.1")
 
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.21.0")
 
-val sbtDevOops = "3.3.2"
+val sbtDevOops = "3.5.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOops)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOops)


### PR DESCRIPTION
# Update `sbt` and `sbt-devoops` plugin versions

- `sbt`: `1.11.7` => `1.12.4`
- `sbt-devoops`: `3.3.2` => `3.5.0`
- The `sbt-devoops` bump applies to `sbt-devoops-scala`, `sbt-devoops-sbt-extra`, and `sbt-devoops-github`.