### PR TITLE
 Update Docusaurus to 3.10.1 and TypeScript to ~6.0.2

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -15,8 +15,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "3.9.2",
-    "@docusaurus/preset-classic": "3.9.2",
+    "@docusaurus/core": "3.10.1",
+    "@docusaurus/faster": "3.10.1",
+    "@docusaurus/preset-classic": "3.10.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -24,10 +25,11 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.9.2",
-    "@docusaurus/tsconfig": "3.9.2",
-    "@docusaurus/types": "3.9.2",
-    "typescript": "~5.6.2"
+    "@docusaurus/module-type-aliases": "3.10.1",
+    "@docusaurus/tsconfig": "3.10.1",
+    "@docusaurus/types": "3.10.1",
+    "@types/react": "^19.0.0",
+    "typescript": "~6.0.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
##  Update Docusaurus to 3.10.1 and TypeScript to ~6.0.2

 - `docusaurus`: `3.9.2` => `3.10.1`
 - `typescript`: `~5.6.2` => `~6.0.2`
 - Added `@docusaurus/faster` `3.10.1` for build performance improvements
 - Added `@types/react` `^19.0.0` to match the React 19 dependency