### PR TITLE
Fix the unreachable NonFatal handling when fetching dirs recursively

### DIFF
--- a/src/main/scala/filef/FileF.scala
+++ b/src/main/scala/filef/FileF.scala
@@ -82,7 +82,8 @@ object FileF {
             getAllSubDirs(restDirs, dirFilter, acc)
       }
 
-    effectOf(getAllSubDirs(Vector(rootDir), dirFilter, Vector.empty).asRight[FileError])
+    effectOf(getAllSubDirs(Vector(rootDir), dirFilter, Vector.empty))
+      .catchNonFatal(FileError.fromNonFatal)
   }
 
   def readBytesFromFile[F[_]: Fx: Monad: MCancel](

--- a/src/main/scala/githubpages/GitHubPagesPlugin.scala
+++ b/src/main/scala/githubpages/GitHubPagesPlugin.scala
@@ -61,13 +61,9 @@ object GitHubPagesPlugin extends AutoPlugin {
         siteDir.siteDir,
         dirFilter = dirFilter
       )
-    ).leftMap {
-      // FIXME: The left type here is FileError, which is not a Throwable, so `NonFatal` can never
-      //  match and this would throw a MatchError. It is unreachable today only because
-      //  FileF.getAllDirsRecursively always returns a Right.
-      case NonFatal(err) =>
-        GitHubError.nonFatalThrowable("Error fetching files recursively", err)
-    }.flatMap {
+    ).leftMap(
+      GitHubError.fileHandling("Fetching files recursively")(_)
+    ).flatMap {
       case Vector() =>
         pureOf(
           GitHubError


### PR DESCRIPTION
# Fix the unreachable `NonFatal` handling when fetching dirs recursively

`FileF.getAllDirsRecursively` never returned a `Left`, so the `leftMap { case NonFatal(err) => ... }` in `GitHubPagesPlugin.pushToGhPages` could never match. Its left type is `FileError`, not a `Throwable`, so had a `Left` ever been produced the partial function would have thrown a `MatchError`.

`getAllDirsRecursively` now catches non-fatal throwables from the directory walk and turns them into a `FileError` via `FileError.fromNonFatal`, instead of unconditionally returning a `Right`. `pushToGhPages` maps that `FileError` with `GitHubError.fileHandling`, matching how the other `FileF` calls in the same method are already handled.

This means an I/O failure while walking the site directory is now reported as a proper error rather than escaping as an unhandled throwable.