### PR TITLE
sbt-github-pages v0.20.0

### DIFF
--- a/changelogs/0.20.0.md
+++ b/changelogs/0.20.0.md
@@ -1,0 +1,32 @@
+## [0.20.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Am25) - 2026-07-10
+
+### New Features
+
+* Support both sbt 1 and sbt 2
+
+  `sbt-github-pages` is now cross-published for both sbt series from a single source tree.
+
+  | sbt series      | Scala   | Artifact                                |
+  |-----------------|---------|-----------------------------------------|
+  | sbt 1 (1.11.2+) | 2.12.20 | `io.kevinlee:sbt-github-pages_2.12_1.0` |
+  | sbt 2 (2.0.1)   | 3.8.4   | `io.kevinlee:sbt-github-pages_sbt2_3`   |
+
+  `addSbtPlugin("io.kevinlee" % "sbt-github-pages" % "0.20.0")` resolves the right one for you,
+  so no change is needed in `project/plugins.sbt`.
+
+  The minimum supported sbt 1 version is unchanged (`1.11.2`).
+
+  Note that building the sbt 2 artifact requires **JDK 17** or later, because that is what the
+  Scala 3.8.4 compiler requires. Using the plugin does not.
+
+### Internal
+
+* All tasks (`publishToGitHubPages`, `gitHubPagesBranchExists`, `gitHubPagesGetCurrentBranch` and
+  `gitHubPagesCreateGitHubPagesBranchIfNotExist`) are now marked `Def.uncached`. sbt 2 caches every
+  task by default, which would have made the `git`-shelling tasks return stale answers within a
+  single session, and would have made `publishToGitHubPages` a no-op on its second invocation.
+
+* Replaced `http4s-blaze-client` with `http4s-ember-client`. Blaze is no longer maintained in step
+  with the rest of http4s (it is pinned at `0.23.17` while http4s itself is at `0.23.36`).
+
+* Added unit tests (hedgehog) and scripted tests for both sbt 1 and sbt 2.


### PR DESCRIPTION
# sbt-github-pages v0.20.0
## [0.20.0](https://github.com/Kevin-Lee/sbt-github-pages/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Arelease%20milestone%3Am25) - 2026-07-10

### New Features

* Support both sbt 1 and sbt 2

  `sbt-github-pages` is now cross-published for both sbt series from a single source tree.

  | sbt series      | Scala   | Artifact                                |
  |-----------------|---------|-----------------------------------------|
  | sbt 1 (1.11.2+) | 2.12.20 | `io.kevinlee:sbt-github-pages_2.12_1.0` |
  | sbt 2 (2.0.1)   | 3.8.4   | `io.kevinlee:sbt-github-pages_sbt2_3`   |

  `addSbtPlugin("io.kevinlee" % "sbt-github-pages" % "0.20.0")` resolves the right one for you,
  so no change is needed in `project/plugins.sbt`.

  The minimum supported sbt 1 version is unchanged (`1.11.2`).

  Note that building the sbt 2 artifact requires **JDK 17** or later, because that is what the
  Scala 3.8.4 compiler requires. Using the plugin does not.

### Internal

* All tasks (`publishToGitHubPages`, `gitHubPagesBranchExists`, `gitHubPagesGetCurrentBranch` and
  `gitHubPagesCreateGitHubPagesBranchIfNotExist`) are now marked `Def.uncached`. sbt 2 caches every
  task by default, which would have made the `git`-shelling tasks return stale answers within a
  single session, and would have made `publishToGitHubPages` a no-op on its second invocation.

* Replaced `http4s-blaze-client` with `http4s-ember-client`. Blaze is no longer maintained in step
  with the rest of http4s (it is pinned at `0.23.17` while http4s itself is at `0.23.36`).

* Added unit tests (hedgehog) and scripted tests for both sbt 1 and sbt 2.
